### PR TITLE
Rule "no_spaces_inside_parenthesis" is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "homepage": "https://github.com/realodix/relax",
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.19",
+        "friendsofphp/php-cs-fixer": "^3.23",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.15",
         "symfony/console": "^6.0"
     },

--- a/src/RuleSet/Sets/Laravel.php
+++ b/src/RuleSet/Sets/Laravel.php
@@ -13,6 +13,10 @@ final class Laravel extends AbstractRuleSet
     protected function rules(): array
     {
         return [
+            // v3.23.0 - deprecated
+            // 'no_spaces_inside_parenthesis' => true,
+            'spaces_inside_parentheses' => true,
+
             // risky
             'self_accessor' => false,
             'psr_autoloading' => false,
@@ -108,7 +112,6 @@ final class Laravel extends AbstractRuleSet
             'no_space_around_double_colon' => true,
             'no_spaces_after_function_name' => true,
             'no_spaces_around_offset' => ['positions' => ['inside', 'outside']],
-            'no_spaces_inside_parenthesis' => true,
             'no_superfluous_phpdoc_tags' => [
                 'allow_mixed' => true,
                 'allow_unused_params' => true,


### PR DESCRIPTION
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/commit/030e18e572fa6c137cb55d2a120a75f60ea4df84