### PR TITLE
Enable all options on `trailing_comma_in_multiline`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "homepage": "https://github.com/realodix/relax",
     "require": {
         "php": "^7.4 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.61",
+        "friendsofphp/php-cs-fixer": "^3.63",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.21",
         "symfony/console": "^5.4.41 || ^6.0 || ^7.0"
     },

--- a/src/RuleSet/Sets/Relax.php
+++ b/src/RuleSet/Sets/Relax.php
@@ -84,8 +84,7 @@ final class Relax extends AbstractRuleSet
             'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['class', 'function', 'const']],
             'single_import_per_statement' => ['group_to_single_imports' => false],
             'space_after_semicolon' => ['remove_in_empty_for_expressions' => true],
-            // TODO: Add 'match' & 'parameters' when PHP 8.0+ is required
-            'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
+            'trailing_comma_in_multiline' => ['elements' => ['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']],
             'unary_operator_spaces' => ['only_dec_inc' => true],
             'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
             'phpdoc_align' => [

--- a/tests/Fixtures/Ruleset/realodixspec_expected.php
+++ b/tests/Fixtures/Ruleset/realodixspec_expected.php
@@ -53,7 +53,7 @@ class RealodixSpec
     public function __construct(
         public int $a,
         public ?int $b = 3600, // 1 hour...
-        public string $c = 'Hello World!'
+        public string $c = 'Hello World!',
     ) {}
 
     /**

--- a/tests/Fixtures/Ruleset/relax-commonbox_expected.php
+++ b/tests/Fixtures/Ruleset/relax-commonbox_expected.php
@@ -227,7 +227,7 @@ final class SelfStaticAccessor
 class SingleLineEmptyBody
 {
     public function __construct(
-        int $ruleSet
+        int $ruleSet,
     ) {}
 
     public function basic__single_line_empty_body() {}

--- a/tests/Fixtures/Ruleset/relax_actual.php
+++ b/tests/Fixtures/Ruleset/relax_actual.php
@@ -793,6 +793,13 @@ if ($foo == true) {
             2
         ];
 
+        // array_destructuring
+        $a = [11, 2, 3];
+        [
+            $c,
+            $d
+        ] = $a;
+
         // arguments
         foo(
             1,

--- a/tests/Fixtures/Ruleset/relax_expected.php
+++ b/tests/Fixtures/Ruleset/relax_expected.php
@@ -766,6 +766,13 @@ class relax_actual extends no_unneeded_import_alias
             2,
         ];
 
+        // array_destructuring
+        $a = [11, 2, 3];
+        [
+            $c,
+            $d,
+        ] = $a;
+
         // arguments
         foo(
             1,
@@ -775,13 +782,13 @@ class relax_actual extends no_unneeded_import_alias
         // parameters
         function foo_trailing_comma_in_multiline(
             $x,
-            $y
+            $y,
         ) {}
 
         // match
         match (true) {
             1 => '1',
-            2 => '2'
+            2 => '2',
         };
 
         // after_heredoc in array

--- a/tests/Fixtures/Ruleset/relax_expected.php
+++ b/tests/Fixtures/Ruleset/relax_expected.php
@@ -821,7 +821,7 @@ class relax_actual extends no_unneeded_import_alias
         function om_ensure_single_line(
             $a = 10,
             $b = 20,
-            $c = 30
+            $c = 30,
         ) {}
         sample(
             1,


### PR DESCRIPTION
Previously it could only be applied to PHP 8.0+, now with PHP-CS-Fixer v3.63.0, it is possible to implement it on PHP 7.4.

- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/control_structure/trailing_comma_in_multiline.rst
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.63.0
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/commit/370943c56a677e636dd339fd1ab7d871b8bebcf2
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/commit/b0a41d1d61cf28a8d3e887fa8c24f155a039902c